### PR TITLE
Documentation Improvements

### DIFF
--- a/README.org
+++ b/README.org
@@ -104,33 +104,33 @@ Synchronously download a JPEG file, then create an Emacs image object from the d
 
 +  ~plz~ :: /(method url &key headers body else finally noquery (as 'string) (then 'sync) (body-type 'text) (decode t decode-s) (connect-timeout plz-connect-timeout) (timeout plz-timeout))/
 
-   Request ~METHOD~ from ~URL~ with curl.  Return the curl process object or, for a synchronous request, the selected result.
+   Request ~method~ from ~url~ with curl.  Return the curl process object or, for a synchronous request, the selected result.
 
-   ~HEADERS~ may be an alist of extra headers to send with the request.
+   ~:headers~ may be an alist of extra headers to send with the request.
 
-   ~BODY-TYPE~ may be ~text~ to send ~BODY~ as text, or ~binary~ to send it as binary.
+   ~:body-type~ may be ~'text~ to send ~body~ as text, or ~:binary~ to send it as binary.
 
-   ~AS~ selects the kind of result to pass to the callback function ~THEN~, or the kind of result to return for synchronous requests.  It may be:
+   ~:as~ selects the kind of result to pass to the callback function ~:then~, or the kind of result to return for synchronous requests.  It may be:
 
    -  ~buffer~ to pass the response buffer.
    -  ~binary~ to pass the response body as an undecoded string.
    -  ~string~ to pass the response body as a decoded string.
    -  ~response~ to pass a ~plz-response~ struct.
    -  A function, to pass its return value; it is called in the response buffer, which is narrowed to the response body (suitable for, e.g. ~json-read~).
-   -  ~file~ to pass a temporary filename to which the response body has been saved without decoding.
-   -  ~(file FILENAME)~ to pass ~FILENAME~ after having saved the response body to it without decoding.  ~FILENAME~ must be a non-existent file; if it exists, it will not be overwritten, and an error will be signaled.
+   -  ~file~ to store to the response body to a temporary file without decoding. The result will be the temp file name.
+   -  ~(file FILENAME)~ to store the undecoded response to a file ~FILENAME~.  ~FILENAME~ must be a non-existent file; if it exists, it will not be overwritten, and an error will be signaled.
 
-   If ~DECODE~ is non-nil, the response body is decoded automatically.  For binary content, it should be nil.  When ~AS~ is ~binary~, ~DECODE~ is automatically set to nil.
+   If ~:decode~ is non-nil, the response body is decoded automatically.  For binary content, it should be nil.  When ~:as~ is ~binary~, ~:decode~ is automatically set to nil.
 
-   ~THEN~ is a callback function, whose sole argument is selected above with ~AS~.  Or ~THEN~ may be ~sync~ to make a synchronous request, in which case the result is returned directly.
+   ~:then~ is a callback function, whose sole argument is selected above with ~:as~.  Or ~:then~ may be ~sync~ to make a synchronous request, in which case the result is returned directly.
 
-   ~ELSE~ is an optional callback function called when the request fails with one argument, a ~plz-error~ struct.  If ~ELSE~ is nil, an error is signaled when the request fails, either ~plz-curl-error~ or ~plz-http-error~ as appropriate, with a ~plz-error~ struct as the error data.  For synchronous requests, this argument is ignored.
+   ~:else~ is an optional callback function called when the request fails with one argument, a ~plz-error~ struct.  If ~:else~ is nil, an error is signaled when the request fails, either ~plz-curl-error~ or ~plz-http-error~ as appropriate, with a ~plz-error~ struct as the error data.  For synchronous requests, this argument is ignored.
 
-   ~FINALLY~ is an optional function called without argument after ~THEN~ or ~ELSE~, as appropriate.  For synchronous requests, this argument is ignored.
+   ~:finally~ is an optional function called without argument after ~:then~ or ~:else~, as appropriate.  For synchronous requests, this argument is ignored.
 
-   ~CONNECT-TIMEOUT~ and ~TIMEOUT~ are a number of seconds that limit how long it takes to connect to a host and to receive a response from a host, respectively.
+   ~:connect-timeout~ and ~:timeout~ are a number of seconds that limit how long it takes to connect to a host and to receive a response from a host, respectively.
 
-   ~NOQUERY~ is passed to ~make-process~, which see.
+   ~:noquery~ is passed to ~make-process~, which see.
 
 ** Queueing
 

--- a/README.org
+++ b/README.org
@@ -108,7 +108,7 @@ Synchronously download a JPEG file, then create an Emacs image object from the d
 
    ~:headers~ may be an alist of extra headers to send with the request.
 
-   ~:body-type~ may be ~'text~ to send ~body~ as text, or ~:binary~ to send it as binary.
+   ~:body-type~ may be ~text~ to send ~body~ as text, or ~:binary~ to send it as binary.
 
    ~:as~ selects the kind of result to pass to the callback function ~:then~, or the kind of result to return for synchronous requests.  It may be:
 

--- a/plz.info
+++ b/plz.info
@@ -114,7 +114,7 @@ string (here, raw JSON):
 
      (plz 'get "https://httpbin.org/user-agent")
 
-     nil
+     "{\n \"user-agent\": \"curl/7.35.0\"\n}\n"
 
    Synchronously ‘GET’ a URL that returns a JSON object, and parse and
 return it as an alist:
@@ -141,7 +141,7 @@ JSON object from the response body, and call a function with the result:
        :then (lambda (alist)
                (message "Result: %s" (alist-get 'data alist))))
 
-     #<process plz-request-curl>
+     Result: {"key":"value"}
 
    Synchronously download a JPEG file, then create an Emacs image object
 from the data:
@@ -149,7 +149,7 @@ from the data:
      (let ((jpeg-data (plz 'get "https://httpbin.org/image/jpeg" :as 'binary)))
        (create-image jpeg-data nil 'data))
 
-image   :type   jpeg   :data   \377\330\377\340
+image   :type   jpeg   :data   ""ÿØÿà^@^PJFIF..."
 
 
 File: README.info,  Node: Functions,  Next: Queueing,  Prev: Examples,  Up: Usage

--- a/plz.info
+++ b/plz.info
@@ -168,7 +168,7 @@ File: README.info,  Node: Functions,  Next: Queueing,  Prev: Examples,  Up: Usag
      ‘:headers’ may be an alist of extra headers to send with the
      request.
 
-     ‘:body-type’ may be ‘'text’ to send ‘body’ as text, or ‘:binary’ to
+     ‘:body-type’ may be ‘text’ to send ‘body’ as text, or ‘:binary’ to
      send it as binary.
 
      ‘:as’ selects the kind of result to pass to the callback function

--- a/plz.info
+++ b/plz.info
@@ -1,4 +1,4 @@
-This is README.info, produced by makeinfo version 5.2 from README.texi.
+This is README.info, produced by makeinfo version 6.7 from README.texi.
 
 INFO-DIR-SECTION Emacs
 START-INFO-DIR-ENTRY
@@ -41,11 +41,13 @@ Usage
 
 * Examples::
 * Functions::
+* Queueing::
 * Tips::
 
 Changelog
 
-* 0.1: 01. 
+* 0.2: 02.
+* 0.1: 01.
 
 Development
 
@@ -88,7 +90,7 @@ File: README.info,  Node: Usage,  Next: Changelog,  Prev: Installation,  Up: Top
 2 Usage
 *******
 
-The only public function is ‘plz’, which sends an HTTP request and
+The main public function is ‘plz’, which sends an HTTP request and
 returns either the result of the specified type (for a synchronous
 request), or the ‘curl’ process object (for asynchronous requests).  For
 asynchronous requests, callback, error-handling, and finalizer functions
@@ -98,6 +100,7 @@ may be specified, as well as various other options.
 
 * Examples::
 * Functions::
+* Queueing::
 * Tips::
 
 
@@ -111,7 +114,7 @@ string (here, raw JSON):
 
      (plz 'get "https://httpbin.org/user-agent")
 
-     "{\n \"user-agent\": \"curl/7.35.0\"\n}\n"
+     nil
 
    Synchronously ‘GET’ a URL that returns a JSON object, and parse and
 return it as an alist:
@@ -121,9 +124,11 @@ return it as an alist:
      ((args)
       (headers
        (Accept . "*/*")
-       (Accept-Encoding . "deflate, gzip")
+       (Accept-Encoding . "deflate, gzip, br")
        (Host . "httpbin.org")
-       (User-Agent . "curl/7.35.0"))
+       (User-Agent . "curl/7.68.0")
+       (X-Amzn-Trace-Id . "Root=1-62e7d1a9-763916ca755682d26c7c1f6d"))
+      (origin . "88.97.43.165")
       (url . "https://httpbin.org/get"))
 
    Asynchronously ‘POST’ a JSON object in the request body, then parse a
@@ -136,7 +141,7 @@ JSON object from the response body, and call a function with the result:
        :then (lambda (alist)
                (message "Result: %s" (alist-get 'data alist))))
 
-     Result: {"key":"value"}
+     #<process plz-request-curl>
 
    Synchronously download a JPEG file, then create an Emacs image object
 from the data:
@@ -144,10 +149,10 @@ from the data:
      (let ((jpeg-data (plz 'get "https://httpbin.org/image/jpeg" :as 'binary)))
        (create-image jpeg-data nil 'data))
 
-     (image :type jpeg :data ""ÿØÿà^@^PJFIF...")
+image   :type   jpeg   :data   \377\330\377\340
 
 
-File: README.info,  Node: Functions,  Next: Tips,  Prev: Examples,  Up: Usage
+File: README.info,  Node: Functions,  Next: Queueing,  Prev: Examples,  Up: Usage
 
 2.2 Functions
 =============
@@ -157,17 +162,17 @@ File: README.info,  Node: Functions,  Next: Tips,  Prev: Examples,  Up: Usage
      (then ’sync) (body-type ’text) (decode t decode-s) (connect-timeout
      plz-connect-timeout) (timeout plz-timeout))_
 
-     Request ‘METHOD’ from ‘URL’ with curl.  Return the curl process
+     Request ‘method’ from ‘url’ with curl.  Return the curl process
      object or, for a synchronous request, the selected result.
 
-     ‘HEADERS’ may be an alist of extra headers to send with the
+     ‘:headers’ may be an alist of extra headers to send with the
      request.
 
-     ‘BODY-TYPE’ may be ‘text’ to send ‘BODY’ as text, or ‘binary’ to
+     ‘:body-type’ may be ‘'text’ to send ‘body’ as text, or ‘:binary’ to
      send it as binary.
 
-     ‘AS’ selects the kind of result to pass to the callback function
-     ‘THEN’, or the kind of result to return for synchronous requests.
+     ‘:as’ selects the kind of result to pass to the callback function
+     ‘:then’, or the kind of result to return for synchronous requests.
      It may be:
 
         • ‘buffer’ to pass the response buffer.
@@ -177,42 +182,78 @@ File: README.info,  Node: Functions,  Next: Tips,  Prev: Examples,  Up: Usage
         • A function, to pass its return value; it is called in the
           response buffer, which is narrowed to the response body
           (suitable for, e.g.  ‘json-read’).
-        • ‘file’ to pass a temporary filename to which the response body
-          has been saved without decoding.
-        • ‘(file FILENAME)’ to pass ‘FILENAME’ after having saved the
-          response body to it without decoding.  ‘FILENAME’ must be a
-          non-existent file; if it exists, it will not be overwritten,
-          and an error will be signaled.
+        • ‘file’ to store to the response body to a temporary file
+          without decoding.  The result will be the temp file name.
+        • ‘(file FILENAME)’ to store the undecoded response to a file
+          ‘FILENAME’.  ‘FILENAME’ must be a non-existent file; if it
+          exists, it will not be overwritten, and an error will be
+          signaled.
 
-     If ‘DECODE’ is non-nil, the response body is decoded automatically.
-     For binary content, it should be nil.  When ‘AS’ is ‘binary’,
-     ‘DECODE’ is automatically set to nil.
+     If ‘:decode’ is non-nil, the response body is decoded
+     automatically.  For binary content, it should be nil.  When ‘:as’
+     is ‘binary’, ‘:decode’ is automatically set to nil.
 
-     ‘THEN’ is a callback function, whose sole argument is selected
-     above with ‘AS’.  Or ‘THEN’ may be ‘sync’ to make a synchronous
+     ‘:then’ is a callback function, whose sole argument is selected
+     above with ‘:as’.  Or ‘:then’ may be ‘sync’ to make a synchronous
      request, in which case the result is returned directly.
 
-     ‘ELSE’ is an optional callback function called when the request
-     fails with one argument, a ‘plz-error’ struct.  If ‘ELSE’ is nil,
+     ‘:else’ is an optional callback function called when the request
+     fails with one argument, a ‘plz-error’ struct.  If ‘:else’ is nil,
      an error is signaled when the request fails, either
      ‘plz-curl-error’ or ‘plz-http-error’ as appropriate, with a
      ‘plz-error’ struct as the error data.  For synchronous requests,
      this argument is ignored.
 
-     ‘FINALLY’ is an optional function called without argument after
-     ‘THEN’ or ‘ELSE’, as appropriate.  For synchronous requests, this
+     ‘:finally’ is an optional function called without argument after
+     ‘:then’ or ‘:else’, as appropriate.  For synchronous requests, this
      argument is ignored.
 
-     ‘CONNECT-TIMEOUT’ and ‘TIMEOUT’ are a number of seconds that limit
-     how long it takes to connect to a host and to receive a response
-     from a host, respectively.
+     ‘:connect-timeout’ and ‘:timeout’ are a number of seconds that
+     limit how long it takes to connect to a host and to receive a
+     response from a host, respectively.
 
-     ‘NOQUERY’ is passed to ‘make-process’, which see.
+     ‘:noquery’ is passed to ‘make-process’, which see.
 
 
-File: README.info,  Node: Tips,  Prev: Functions,  Up: Usage
+File: README.info,  Node: Queueing,  Next: Tips,  Prev: Functions,  Up: Usage
 
-2.3 Tips
+2.3 Queueing
+============
+
+‘plz’ provides a simple system for queueing HTTP requests.  First, make
+a ‘plz-queue’ struct by calling ‘make-plz-queue’.  Then call ‘plz-queue’
+with the struct as the first argument, and the rest of the arguments
+being the same as those passed to ‘plz’.  Then call ‘plz-run’ to run the
+queued requests.
+
+   All of the queue-related functions return the queue as their value,
+making them easy to use.  For example:
+
+     (defvar my-queue (make-plz-queue :limit 2))
+
+     (plz-run
+      (plz-queue my-queue
+        'get "https://httpbin.org/get?foo=0"
+        :then (lambda (body) (message "%s" body))))
+
+   Or:
+
+     (let ((queue (make-plz-queue :limit 2))
+           (urls '("https://httpbin.org/get?foo=0"
+                   "https://httpbin.org/get?foo=1")))
+       (plz-run
+        (dolist (url urls queue)
+          (plz-queue queue 'get url
+            :then (lambda (body) (message "%s" body))))))
+
+   You may also clear a queue with ‘plz-clear’, which cancels any active
+or queued requests and calls their ‘:else’ functions.  And ‘plz-length’
+returns the number of a queue’s active and queued requests.
+
+
+File: README.info,  Node: Tips,  Prev: Queueing,  Up: Usage
+
+2.4 Tips
 ========
 
    • You can customize settings in the ‘plz’ group, but this can only be
@@ -227,12 +268,22 @@ File: README.info,  Node: Changelog,  Next: Credits,  Prev: Usage,  Up: Top
 
 * Menu:
 
-* 0.1: 01. 
+* 0.2: 02.
+* 0.1: 01.
 
 
-File: README.info,  Node: 01,  Up: Changelog
+File: README.info,  Node: 02,  Next: 01,  Up: Changelog
 
-3.1 0.1
+3.1 0.2
+=======
+
+*Added*
+   • Simple request queueing.
+
+
+File: README.info,  Node: 01,  Prev: 02,  Up: Changelog
+
+3.2 0.1
 =======
 
 Initial release.
@@ -292,19 +343,21 @@ GPLv3
 
 Tag Table:
 Node: Top199
-Node: Installation1032
-Node: GNU ELPA1175
-Node: Manual1421
-Node: Usage1727
-Node: Examples2215
-Node: Functions3582
-Node: Tips6473
-Node: Changelog6775
-Node: 016901
-Node: Credits6984
-Node: Development7350
-Node: Copyright assignment7864
-Node: License8452
+Node: Installation1055
+Node: GNU ELPA1198
+Node: Manual1444
+Node: Usage1750
+Node: Examples2251
+Node: Functions3684
+Node: Queueing6593
+Node: Tips7851
+Node: Changelog8152
+Node: 028288
+Node: 018405
+Node: Credits8499
+Node: Development8865
+Node: Copyright assignment9379
+Node: License9967
 
 End Tag Table
 


### PR DESCRIPTION
Subjective, but I think these changes make the doc easier to interpret. Plus I refreshed the .info, which actually caused me some ire:

I did previously go further, showing options like `data` as `'data` so as to be clear how to use them, but github and the info org export had different ideas as to how to interpret the markup for inline code with a `'` inside.

Still, I think this is a bit clearer. But as I say subjective so I won't take offence if you reject some or all of this :) 