### PR TITLE
Don't delete preexisting files with `:as 'file` (data-loss)

### DIFF
--- a/README.org
+++ b/README.org
@@ -179,6 +179,10 @@ You may also clear a queue with ~plz-clear~, which cancels any active or queued 
 :TOC:      :depth 0
 :END:
 
+** 0.7.2-pre
+
+Nothing new yet.
+
 ** 0.7.1
 
 *Fixes*

--- a/README.org
+++ b/README.org
@@ -181,7 +181,8 @@ You may also clear a queue with ~plz-clear~, which cancels any active or queued 
 
 ** 0.7.2-pre
 
-Nothing new yet.
+*Fixes*
++ Don't delete preexisting files when downloading to a file.  ([[https://github.com/alphapapa/plz.el/pull/41][#41]]. Thanks to [[https://github.com/josephmturner][Joseph Turner]].)
 
 ** 0.7.1
 

--- a/plz.el
+++ b/plz.el
@@ -5,7 +5,7 @@
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; Maintainer: Adam Porter <adam@alphapapa.net>
 ;; URL: https://github.com/alphapapa/plz.el
-;; Version: 0.7.1
+;; Version: 0.7.2-pre
 ;; Package-Requires: ((emacs "26.3"))
 ;; Keywords: comm, network, http
 

--- a/plz.el
+++ b/plz.el
@@ -449,6 +449,8 @@ NOQUERY is passed to `make-process', which see.
                       (progn
                         (write-region (point-min) (point-max) filename)
                         (funcall then filename))
+                    (file-already-exists
+                     (funcall then (make-plz-error :message (format "error while writing to file %S: %S" filename err))))
                     ;; In case of an error writing to the file, delete the temp file
                     ;; and signal the error.  Ignore any errors encountered while
                     ;; deleting the file, which would obscure the original error.
@@ -463,6 +465,8 @@ NOQUERY is passed to `make-process', which see.
               (progn
                 (write-region (point-min) (point-max) filename nil nil nil 'excl)
                 (funcall then filename))
+            (file-already-exists
+             (funcall then (make-plz-error :message (format "error while writing to file %S: %S" filename err))))
             ;; Since we are creating the file, it seems sensible to delete it in case of an
             ;; error while writing to it (e.g. a disk-full error).  And we ignore any errors
             ;; encountered while deleting the file, which would obscure the original error.

--- a/plz.info
+++ b/plz.info
@@ -46,6 +46,7 @@ Usage
 
 Changelog
 
+* 0.7.2-pre: 072-pre.
 * 0.7.1: 071.
 * 0.7: 07.
 * 0.6: 06.
@@ -293,6 +294,7 @@ File: README.info,  Node: Changelog,  Next: Credits,  Prev: Usage,  Up: Top
 
 * Menu:
 
+* 0.7.2-pre: 072-pre.
 * 0.7.1: 071.
 * 0.7: 07.
 * 0.6: 06.
@@ -308,9 +310,17 @@ File: README.info,  Node: Changelog,  Next: Credits,  Prev: Usage,  Up: Top
 * 0.1: 01.
 
 
-File: README.info,  Node: 071,  Next: 07,  Up: Changelog
+File: README.info,  Node: 072-pre,  Next: 071,  Up: Changelog
 
-3.1 0.7.1
+3.1 0.7.2-pre
+=============
+
+Nothing new yet.
+
+
+File: README.info,  Node: 071,  Next: 07,  Prev: 072-pre,  Up: Changelog
+
+3.2 0.7.1
 =========
 
 *Fixes*
@@ -320,7 +330,7 @@ File: README.info,  Node: 071,  Next: 07,  Up: Changelog
 
 File: README.info,  Node: 07,  Next: 06,  Prev: 071,  Up: Changelog
 
-3.2 0.7
+3.3 0.7
 =======
 
 *Changes*
@@ -363,7 +373,7 @@ File: README.info,  Node: 07,  Next: 06,  Prev: 071,  Up: Changelog
 
 File: README.info,  Node: 06,  Next: 054,  Prev: 07,  Up: Changelog
 
-3.3 0.6
+3.4 0.6
 =======
 
 *Additions*
@@ -381,7 +391,7 @@ File: README.info,  Node: 06,  Next: 054,  Prev: 07,  Up: Changelog
 
 File: README.info,  Node: 054,  Next: 053,  Prev: 06,  Up: Changelog
 
-3.4 0.5.4
+3.5 0.5.4
 =========
 
 *Fixes*
@@ -391,7 +401,7 @@ File: README.info,  Node: 054,  Next: 053,  Prev: 06,  Up: Changelog
 
 File: README.info,  Node: 053,  Next: 052,  Prev: 054,  Up: Changelog
 
-3.5 0.5.3
+3.6 0.5.3
 =========
 
 *Fixes*
@@ -402,7 +412,7 @@ File: README.info,  Node: 053,  Next: 052,  Prev: 054,  Up: Changelog
 
 File: README.info,  Node: 052,  Next: 051,  Prev: 053,  Up: Changelog
 
-3.6 0.5.2
+3.7 0.5.2
 =========
 
 *Fixes*
@@ -412,7 +422,7 @@ File: README.info,  Node: 052,  Next: 051,  Prev: 053,  Up: Changelog
 
 File: README.info,  Node: 051,  Next: 05,  Prev: 052,  Up: Changelog
 
-3.7 0.5.1
+3.8 0.5.1
 =========
 
 *Fixes*
@@ -422,7 +432,7 @@ File: README.info,  Node: 051,  Next: 05,  Prev: 052,  Up: Changelog
 
 File: README.info,  Node: 05,  Next: 04,  Prev: 051,  Up: Changelog
 
-3.8 0.5
+3.9 0.5
 =======
 
 *Additions*
@@ -432,8 +442,8 @@ File: README.info,  Node: 05,  Next: 04,  Prev: 051,  Up: Changelog
 
 File: README.info,  Node: 04,  Next: 03,  Prev: 05,  Up: Changelog
 
-3.9 0.4
-=======
+3.10 0.4
+========
 
 *Additions*
    • Support for HTTP ‘HEAD’ requests.  (Thanks to Inc.  for
@@ -459,7 +469,7 @@ File: README.info,  Node: 04,  Next: 03,  Prev: 05,  Up: Changelog
 
 File: README.info,  Node: 03,  Next: 021,  Prev: 04,  Up: Changelog
 
-3.10 0.3
+3.11 0.3
 ========
 
 *Additions*
@@ -475,7 +485,7 @@ File: README.info,  Node: 03,  Next: 021,  Prev: 04,  Up: Changelog
 
 File: README.info,  Node: 021,  Next: 02,  Prev: 03,  Up: Changelog
 
-3.11 0.2.1
+3.12 0.2.1
 ==========
 
 *Fixes*
@@ -484,7 +494,7 @@ File: README.info,  Node: 021,  Next: 02,  Prev: 03,  Up: Changelog
 
 File: README.info,  Node: 02,  Next: 01,  Prev: 021,  Up: Changelog
 
-3.12 0.2
+3.13 0.2
 ========
 
 *Added*
@@ -493,7 +503,7 @@ File: README.info,  Node: 02,  Next: 01,  Prev: 021,  Up: Changelog
 
 File: README.info,  Node: 01,  Prev: 02,  Up: Changelog
 
-3.13 0.1
+3.14 0.1
 ========
 
 Initial release.
@@ -553,32 +563,33 @@ GPLv3
 
 Tag Table:
 Node: Top199
-Node: Installation1194
-Node: GNU ELPA1337
-Node: Manual1583
-Node: Usage1889
-Node: Examples2390
-Node: Functions3757
-Node: Queueing7454
-Node: Tips8837
-Node: Changelog9138
-Node: 0719413
-Node: 079614
-Node: 0611502
-Node: 05412113
-Node: 05312356
-Node: 05212672
-Node: 05112879
-Node: 0513131
-Node: 0413337
-Node: 0314243
-Node: 02114693
-Node: 0214844
-Node: 0114975
-Node: Credits15071
-Node: Development15437
-Node: Copyright assignment15951
-Node: License16539
+Node: Installation1216
+Node: GNU ELPA1359
+Node: Manual1605
+Node: Usage1911
+Node: Examples2412
+Node: Functions3779
+Node: Queueing7476
+Node: Tips8859
+Node: Changelog9160
+Node: 072-pre9457
+Node: 0719569
+Node: 079786
+Node: 0611674
+Node: 05412285
+Node: 05312528
+Node: 05212844
+Node: 05113051
+Node: 0513303
+Node: 0413509
+Node: 0314417
+Node: 02114867
+Node: 0215018
+Node: 0115149
+Node: Credits15245
+Node: Development15611
+Node: Copyright assignment16125
+Node: License16713
 
 End Tag Table
 

--- a/plz.info
+++ b/plz.info
@@ -315,7 +315,10 @@ File: README.info,  Node: 072-pre,  Next: 071,  Up: Changelog
 3.1 0.7.2-pre
 =============
 
-Nothing new yet.
+*Fixes*
+   • Don’t delete preexisting files when downloading to a file.  (#41
+     (https://github.com/alphapapa/plz.el/pull/41).  Thanks to Joseph
+     Turner (https://github.com/josephmturner).)
 
 
 File: README.info,  Node: 071,  Next: 07,  Prev: 072-pre,  Up: Changelog
@@ -573,23 +576,23 @@ Node: Queueing7476
 Node: Tips8859
 Node: Changelog9160
 Node: 072-pre9457
-Node: 0719569
-Node: 079786
-Node: 0611674
-Node: 05412285
-Node: 05312528
-Node: 05212844
-Node: 05113051
-Node: 0513303
-Node: 0413509
-Node: 0314417
-Node: 02114867
-Node: 0215018
-Node: 0115149
-Node: Credits15245
-Node: Development15611
-Node: Copyright assignment16125
-Node: License16713
+Node: 0719753
+Node: 079970
+Node: 0611858
+Node: 05412469
+Node: 05312712
+Node: 05213028
+Node: 05113235
+Node: 0513487
+Node: 0413693
+Node: 0314601
+Node: 02115051
+Node: 0215202
+Node: 0115333
+Node: Credits15429
+Node: Development15795
+Node: Copyright assignment16309
+Node: License16897
 
 End Tag Table
 


### PR DESCRIPTION
I think deleting the temp file makes sense, but existing files should be left alone.