### PR TITLE
Support streaming response

### DIFF
--- a/plz.el
+++ b/plz.el
@@ -755,6 +755,7 @@ argument passed to `plz--sentinel', which see."
         (pcase-exhaustive status
           ((or 0 "finished\n")
            ;; Curl exited normally: check HTTP status code.
+           (widen)
            (goto-char (point-min))
            (plz--skip-proxy-headers)
            (while (plz--skip-redirect-headers))

--- a/plz.el
+++ b/plz.el
@@ -254,7 +254,7 @@ connection phase and waiting to receive the response (the
 
 ;;;;; Public
 
-(cl-defun plz (method url &rest rest &key headers body else finally noquery
+(cl-defun plz (method url &rest rest &key headers body else finally noquery process-filter
                       (as 'string) (then 'sync)
                       (body-type 'text) (decode t decode-s)
                       (connect-timeout plz-connect-timeout) (timeout plz-timeout))
@@ -404,6 +404,7 @@ NOQUERY is passed to `make-process', which see.
                                 :coding 'binary
                                 :command (append (list plz-curl-program) curl-command-line-args)
                                 :connection-type 'pipe
+                                :filter process-filter
                                 :sentinel #'plz--sentinel
                                 :stderr stderr-process
                                 :noquery noquery))


### PR DESCRIPTION
Hi @alphapapa and @ahyatt,

This changed adds support for streaming responses by adding a process filter and a callback function. The process filter is based on the default default process filter as described in the manual. It inserts the response into the process buffer. Additionally, if a callback function is provided by the `during` keyword, it is called every time a part of the response body is received.

I'm interested in writing a curl based provider for the `llm` library and saw the following issue here:
https://github.com/alphapapa/plz.el/issues/42

Would you like to collaborate in resolving this issue?

Thanks, Roman. 