### PR TITLE
Added PATCH method

### DIFF
--- a/README.org
+++ b/README.org
@@ -190,7 +190,9 @@ You may also clear a queue with ~plz-clear~, which cancels any active or queued 
 
 ** 0.10-pre
 
-Nothing new yet.
+*Additions*
+
++ Support for the HTTP PATCH method.  ([[https://github.com/alphapapa/plz.el/pull/49][#49]].  Thanks to [[https://github.com/fpvmorais][Pedro Morais]].)
 
 ** 0.9.1
 

--- a/plz.el
+++ b/plz.el
@@ -456,7 +456,7 @@ into the process buffer.
                                       ;; requests which output to the terminal.
                                       (list (cons "--dump-header" null-device))))
                                    (pcase method
-                                     ((or 'put 'post)
+                                     ((or 'put 'post 'patch)
                                       (list
                                        ;; It appears that this must be the last argument
                                        ;; in order to pass data on the rest of STDIN.

--- a/tests/test-plz.el
+++ b/tests/test-plz.el
@@ -171,6 +171,20 @@ in URL-encoded form)."
       (should (string-match "curl" .headers.User-Agent))
       (should (string= "value" (alist-get 'key (json-read-from-string .data)))))))
 
+(plz-deftest plz-patch-json-string nil
+  (let* ((json-string (json-encode (list (cons "key" "value"))))
+         (response-json)
+         (process (plz 'patch (url "/patch")
+                    :headers '(("Content-Type" . "application/json"))
+                    :body json-string
+                    :as #'json-read
+                    :then (lambda (json)
+                            (setf response-json json)))))
+    (plz-test-wait process)
+    (let-alist response-json
+      (should (string-match "curl" .headers.User-Agent))
+      (should (string= "value" (alist-get 'key (json-read-from-string .data)))))))
+
 (plz-deftest plz-post-jpeg-string nil
   (let* ((jpeg-to-upload (plz 'get (url "/image/jpeg")
                            :as 'binary :then 'sync))


### PR DESCRIPTION
Hello,

This is just a tiny contribution, I'm currently running Emacs on a Windows SO and needed to create pull requests on DevAzure.
One of the endpoints demands the PATCH method.

Being using this for a few weeks and works properly. 

One issue I've found is that it does not work with cURL from Microsoft located on  `C:\Windows\System32\curl.exe`. (Version 8.4.0). Not sure exactly why.
After installing the Curl version (8.6.0) via Scoop and setting this variable on Emacs:
`(setq plz-curl-program "C:\\Tools\\scoop\\apps\\curl\\current\\bin\\curl.exe")`
Everything started working correctly. Not sure if it's worth it to add to the documentation, but it might help someone in the same situation as me.

Thank you so much for your amazing packages and work.
All the best from Portugal

Pedro