### PR TITLE
Don't yes-or-no-p query the user when killing plz process buffers

### DIFF
--- a/plz.el
+++ b/plz.el
@@ -403,9 +403,9 @@ into the process buffer.
           ;; default-directory has since been removed).  It's unclear what the best
           ;; directory is, but this seems to make sense, and it should still exist.
           temporary-file-directory)
-         (process-buffer (generate-new-buffer " *plz-request-curl*"))
+         (process-buffer (generate-new-buffer " *plz-request-curl*" t))
          (stderr-process (make-pipe-process :name "plz-request-curl-stderr"
-                                            :buffer (generate-new-buffer " *plz-request-curl-stderr*")
+                                            :buffer (generate-new-buffer " *plz-request-curl-stderr*" t)
                                             :noquery t
                                             :sentinel #'plz--stderr-sentinel))
          (process (make-process :name "plz-request-curl"


### PR DESCRIPTION
The current behavior when interrupting a sync request by C-g or in other way, externally - e.g. with `with-timeout`, Emacs unexpectedly asks if I really want to kill the curl process buffer.
E.g. when interrupting this long-running request with C-g:
```
(plz 'get "http://httpbin.org/delay/10")
```

Emacs asks if I want to really kill the curl buffer. This is unexpected, as the library itself should never be interactive.
It even does this in `--batch` mode, which I caught here: https://github.com/mkcms/compiler-explorer.el/actions/runs/9200670124/job/25307608066#step:6:148

I have signed the FSF papers a couple of years ago and already contributed to Emacs, so this is good to go.