### PR TITLE
Fix: (plz) Create empty directories when outputting to a file

### DIFF
--- a/README.org
+++ b/README.org
@@ -194,6 +194,10 @@ You may also clear a queue with ~plz-clear~, which cancels any active or queued 
 
 + The minimum supported Emacs version is now 27.1.  (It is no longer practical to test ~plz~ with Emacs versions older than 27.1.  For Emacs 26.3, an earlier version of ~plz~ may be used, or this version might be compatible, with or without minor changes, which the maintainer cannot offer support for.)
 
+*Additions*
+
++ When downloading to a file, the ~--create-dirs~ option is passed to Curl so it will create any necessary subdirectories automatically.  ([[https://github.com/alphapapa/plz.el/pull/64][#64]].  Thanks to [[https://github.com/josephmturner][Joseph Turner]] and [[https://ushin.org/][USHIN]].)
+
 *Changes*
 
 + Option ~plz-timeout~ is removed.  (It was the default value for ~plz~'s ~:timeout~ argument, which is passed to Curl as its ~--max-time~ argument, limiting the total duration of a request operation.  This argument should be unset by default, because larger or slower downloads might not finish within a certain duration, and it is surprising to the user to have this option set by default, potentially causing requests to timeout unnecessarily.)

--- a/plz.el
+++ b/plz.el
@@ -430,7 +430,8 @@ into the process buffer.
          (curl-config-header-args (cl-loop for (key . value) in headers
                                            collect (cons "--header" (format "%s: %s" key value))))
          (curl-config-args (append curl-config-header-args
-                                   (list (cons "--url" url))
+                                   (list (cons "--url" url)
+                                         (cons "--create-dirs" ""))
                                    (when connect-timeout
                                      (list (cons "--connect-timeout"
                                                  (number-to-string connect-timeout))))


### PR DESCRIPTION
See [this hyperdrive.el issue](https://todo.sr.ht/~ushin/ushin/208).